### PR TITLE
feat: Add typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "@cadienvan/timed-cache",
-  "version": "0.0.1",
+  "name": "@cadienvan/key-value-cache",
+  "version": "0.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@cadienvan/timed-cache",
-      "version": "0.0.1",
+      "name": "@cadienvan/key-value-cache",
+      "version": "0.2.5",
       "license": "MIT",
       "devDependencies": {
-        "tsc": "^2.0.4"
+        "tsc": "^2.0.4",
+        "typescript": "^4.8.4"
       }
     },
     "node_modules/tsc": {
@@ -20,6 +21,19 @@
       "bin": {
         "tsc": "bin/tsc"
       }
+    },
+    "node_modules/typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     }
   },
   "dependencies": {
@@ -27,6 +41,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/tsc/-/tsc-2.0.4.tgz",
       "integrity": "sha512-fzoSieZI5KKJVBYGvwbVZs/J5za84f2lSTLPYf6AGiIf43tZ3GNrI1QzTLcjtyDDP4aLxd46RTZq1nQxe7+k5Q==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc"
+    "clean": "rm -fr dist",
+    "build": "npm run clean && tsc"
   },
   "prepublish": "tsc",
   "devDependencies": {
-    "tsc": "^2.0.4"
+    "tsc": "^2.0.4",
+    "typescript": "^4.8.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Add typescript as dependency for user that doesn't have typescript installed.
- Add a clean script for deleting the `dist` folder.