### PR TITLE
fix: dist folder already defined in tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "ts-types": "tsc --emitDeclarationOnly --outDir dist",
+    "ts-types": "tsc --emitDeclarationOnly",
     "build": "npm run lint && rimraf dist && node esbuild.js && npm run ts-types",
     "demo-test": "for file in demo/*.js; do node $file; done",
     "prettier": "prettier --write .",


### PR DESCRIPTION
The dist folder is present as an argument ad also in the tsconfig file.